### PR TITLE
feat: add support for Obsidian 1.9+ web viewer and improve iframe fal…

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -23,7 +23,7 @@ jobs:
             - name: draft release
               uses: softprops/action-gh-release@v1
               with:
-                  draft: true
+                  draft: false
                   files: |
                       obsidian-open-link-with-${{ github.ref_name }}.zip
                       manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.11
+
+-   added: support for Obsidian 1.9+ web viewer as a new browser option [#36](https://github.com/gitgud5000/obsidian-open-link-with/issues/36)
+-   updated: minimum Obsidian version requirement to 1.9 for web viewer support
+-   improved: web viewer now uses Obsidian's native browser view when available, and falls back to an enhanced iframe implementation for compatibility
+-   improved: modifier key bindings and focus options now also apply to the web viewer
+
 ## 0.1.10
 
 -   fixed: no longer ignores non-clickable elements with a valid pending URL [#20](https://github.com/mamoruds/obsidian-open-link-with/issues/20)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Select which browser you want to open external link with in plugin's setting men
 <img src="https://github.com/MamoruDS/obsidian-open-link-with/raw/main/assets/screenshot_00.png" style="width: 650px; max-width: 100%;">
 </p>
 
+### Web Viewer (Obsidian 1.9+)
+
+Starting with Obsidian 1.9, this plugin supports the new **web viewer** option which provides an enhanced browser experience within Obsidian. This feature leverages Obsidian's built-in web browsing capabilities for a more integrated and native browsing experience.
+
+The web viewer option:
+- Uses Obsidian's native browser view when available (Obsidian 1.9+)
+- Falls back gracefully to an enhanced iframe implementation for compatibility
+- Provides better security and modern web features
+- Supports all the same modifier key bindings as other browser options
+
+To use the web viewer, simply select "web viewer (Obsidian 1.9+)" from the Browser dropdown in the plugin settings.
+
 ### Customization
 
 Put your custom profile in plugin's settings menu. Profile should contain `name(string): commands(string[])` which is demonstrated in the following:

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
     "id": "obsidian-open-link-with",
     "name": "Open Link With",
-    "version": "0.1.10",
-    "minAppVersion": "1.1",
+    "version": "0.1.11",
+    "minAppVersion": "1.9.0",
     "description": "Open external link with specific browser / in-app view in Obsidian",
-    "author": "MamoruDS",
-    "authorUrl": "https://github.com/MamoruDS",
+    "author": "gitgud5000",
+    "authorUrl": "https://github.com/gitgud5000",
     "isDesktopOnly": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-open-link-with",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "Open external link with specific browser / in-app view in Obsidian",
     "main": "dist/main.js",
     "scripts": {

--- a/src/click.ts
+++ b/src/click.ts
@@ -163,7 +163,17 @@ class LocalDocClickHandler {
         if (this.handleAuxClick && evt.button === 2) {
             fire = false
         }
+        if (!fire) {
+            return false
+        }
+        // We are going to handle this click ourselves; prevent default and stop propagation
         evt.preventDefault()
+        try {
+            evt.stopImmediatePropagation()
+            evt.stopPropagation()
+        } catch (e) {
+            // no-op: older environments may not support stopImmediatePropagation on synthetic events
+        }
         if (this.clickUilts._plugin.settings.enableLog) {
             log('info', 'click event (LocalDocClickHandler)', {
                 is_aux: this.handleAuxClick,
@@ -172,9 +182,6 @@ class LocalDocClickHandler {
                 modifiers,
                 btn: evt.button,
             })
-        }
-        if (!fire) {
-            return false
         }
         const dummy = evt.doc.createElement('a')
         const cid = genRandomStr(4)

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -28,6 +28,11 @@ const BROWSER_IN_APP_LAST: ProfileDisplay = {
     display: 'in-app view',
 }
 
+const BROWSER_WEB_VIEWER: ProfileDisplay = {
+    val: '_web_viewer',
+    display: 'web viewer (Obsidian 1.9+)',
+}
+
 const _isExecutableExist = async (fp: string): Promise<boolean> => {
     return existsSync(fp)
 }
@@ -295,6 +300,7 @@ export {
     BROWSER_GLOBAL,
     BROWSER_IN_APP,
     BROWSER_IN_APP_LAST,
+    BROWSER_WEB_VIEWER,
     MODIFIER_TEXT,
     MODIFIER_TEXT_FALLBACK,
     PRESET_BROWSERS,

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
     BROWSER_GLOBAL,
     BROWSER_IN_APP,
     BROWSER_IN_APP_LAST,
+    BROWSER_WEB_VIEWER,
     MODIFIER_TEXT,
     MODIFIER_TEXT_FALLBACK,
 } from './constant'
@@ -147,6 +148,10 @@ export default class OpenLinkPlugin
             // in-app view
             if (profileName === BROWSER_IN_APP.val) {
                 evt.preventDefault()
+                try {
+                    evt.stopImmediatePropagation()
+                    evt.stopPropagation()
+                } catch {}
                 this._viewmgr.createView(url, ViewMode.NEW, {
                     focus: matchedMB?.focusOnView,
                     paneType,
@@ -155,7 +160,24 @@ export default class OpenLinkPlugin
             }
             if (profileName === BROWSER_IN_APP_LAST.val) {
                 evt.preventDefault()
+                try {
+                    evt.stopImmediatePropagation()
+                    evt.stopPropagation()
+                } catch {}
                 this._viewmgr.createView(url, ViewMode.LAST, {
+                    focus: matchedMB?.focusOnView,
+                    paneType,
+                })
+                return
+            }
+            // web viewer (Obsidian 1.9+)
+            if (profileName === BROWSER_WEB_VIEWER.val) {
+                evt.preventDefault()
+                try {
+                    evt.stopImmediatePropagation()
+                    evt.stopPropagation()
+                } catch {}
+                this._viewmgr.createWebViewerView(url, ViewMode.NEW, {
                     focus: matchedMB?.focusOnView,
                     paneType,
                 })
@@ -335,6 +357,7 @@ class SettingTab extends PluginSettingTab {
                     BROWSER_SYSTEM,
                     BROWSER_IN_APP_LAST,
                     BROWSER_IN_APP,
+                    BROWSER_WEB_VIEWER,
                     ...Object.keys(
                         this.plugin.profiles.getBrowsersCMD(
                             this.plugin.settings.custom
@@ -399,6 +422,7 @@ class SettingTab extends PluginSettingTab {
                     BROWSER_GLOBAL,
                     BROWSER_IN_APP_LAST,
                     BROWSER_IN_APP,
+                    BROWSER_WEB_VIEWER,
                     ...Object.keys(
                         this.plugin.profiles.getBrowsersCMD(
                             this.plugin.settings.custom
@@ -438,7 +462,8 @@ class SettingTab extends PluginSettingTab {
                 toggle.toggleEl.setAttribute('id', 'oolw-view-focus-toggle')
                 if (
                     mb.browser === BROWSER_IN_APP.val ||
-                    mb.browser === BROWSER_IN_APP_LAST.val
+                    mb.browser === BROWSER_IN_APP_LAST.val ||
+                    mb.browser === BROWSER_WEB_VIEWER.val
                 ) {
                     toggle.setDisabled(false)
                     toggle.setValue(mb.focusOnView)
@@ -448,7 +473,7 @@ class SettingTab extends PluginSettingTab {
                     toggle.setValue(false)
                 }
                 toggle.setTooltip(
-                    'Focus on view after opening/updating (in-app browser only)'
+                    'Focus on view after opening/updating (in-app browser and web viewer only)'
                 )
                 toggle.onChange(async (val) => {
                     this.plugin.settings.modifierBindings.find(


### PR DESCRIPTION
This pull request introduces support for the new Obsidian 1.9+ web viewer as a browser option, enhances the in-app browsing experience, and updates documentation and metadata to reflect these changes. The most significant update is the addition of a native web viewer integration, with a fallback to an enhanced iframe when unavailable. There are also improvements to modifier key handling and focus options for browser views.

**Web Viewer Support and In-App Browsing Enhancements**
- Added a new `web viewer (Obsidian 1.9+)` browser option, which uses Obsidian's native web viewer when available and falls back to an enhanced iframe implementation for compatibility. This includes the new `WebViewerView` class and associated logic in `ViewMgr` to detect and use the core plugin or fallback as needed (`src/constant.ts`, `src/main.ts`, `src/view.ts`). 

**Event Handling Improvements**
- Improved click event handling to ensure default actions and event propagation are consistently prevented for all in-app and web viewer cases (`src/click.ts`, `src/main.ts`). 

**Release Process**
- Changed the GitHub Actions workflow to publish releases as non-draft by default (`.github/workflows/build_and_release.yml`).

- updated: minimum Obsidian version requirement to 1.9
- improved: web viewer uses native browser view when available
- improved: iframe fallback for enhanced compatibility and security
- added: modifier key bindings for web viewer
- updated: CHANGELOG and README for new features